### PR TITLE
add pxblue/colors to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "^8.1.2",
     "@angular/platform-browser-dynamic": "^8.1.2",
     "@angular/router": "^8.1.2",
+    "@pxblue/colors": "^2.0.0",
     "@pxblue/themes": "^2.0.0",
     "core-js": "^2.5.4",
     "hammerjs": "^2.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,6 +324,11 @@
   resolved "https://registry.yarnpkg.com/@pxblue/colors/-/colors-1.0.13.tgz#1ed76734267f77dd4b390836f61d01439fc35132"
   integrity sha512-tneNNYclHmNNIbo6J7XXEumoJZLBXqeO2LFufWxRvIs5yeVVfaJN3zWREl1oo5KP67aDixYgEKB7LH0oeTL+lQ==
 
+"@pxblue/colors@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@pxblue/colors/-/colors-2.0.0.tgz#fa7d2abde80485537f26521df4c3f6e56dd93361"
+  integrity sha512-1JoCVC17nHmC6bbqg2nCAHJgJLHAWNIAmS/UZ3h8u0TnvU5C6qI+CpCrn/sP6bNSQ3LLhEkdVpjKna1kxCXdhg==
+
 "@pxblue/themes@^2.0.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@pxblue/themes/-/themes-2.1.0.tgz#cae223f37aac743697a8f3cc835b16b56dfc694e"


### PR DESCRIPTION
Fix the `dev/null` issue displayed in Stackblitz:
![image](https://user-images.githubusercontent.com/8997218/72265202-1211d780-35ea-11ea-86e5-92ce2a3751f6.png)

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- yarn add @pxblue/colors to make the stackblitz example work.
